### PR TITLE
Added `start_model_dir` in the config

### DIFF
--- a/config.pro
+++ b/config.pro
@@ -14,6 +14,7 @@
 !   05    2020/02/14   Savoldi   Added modelcheck path and matlab string
 !   06    2021/04/20   Savoldi   Added white background for render scene as default
 !   07    2021/09/21   Protopapa Added "hole_parameter_file_path" as ".\config"
+!   08    2021/10/28   Shah      Added "start_model_dir" as ".config\standard_files"
 !
 !
 !
@@ -342,3 +343,5 @@ default_scene_filename .\config\render_scene\IIT_default_scene.scn
 hole_parameter_file_path .\config
 hole_file_resolution replace_with_external
 pro_surface_finish_dir .\config\symbols\surf_finish
+
+start_model_dir .\config\standard_files


### PR DESCRIPTION
I modified the cofig.pro to add the start part directory (`start_model_dir`) as the `.config\standard_files`. 

This way every time we create a new part/assembly without the template (for example for creating commercial parts), it will directly load the [standard_files](https://github.com/icub-tech-iit/cad-libraries/tree/master/config/standard_files) subfolder of our cad-libraries that has all the necessary start parts. 

![image](https://user-images.githubusercontent.com/16266334/139286104-9844f870-562a-4697-a1ad-fe847ad34101.png)

cc @icub-tech-iit/silo-mech 
