### PR TITLE
Updating default path for retrieving/saving tables

### DIFF
--- a/config.pro
+++ b/config.pro
@@ -346,3 +346,4 @@ pro_surface_finish_dir .\config\symbols\surf_finish
 
 start_model_dir .\config\standard_files
 display shadewithedges
+pro_table_dir .\config\tables


### PR DESCRIPTION
I noticed that when you use tables in drawings, Creo brings you to some random, not-so-useful path:

![immagine](https://user-images.githubusercontent.com/84333301/144618434-776b702f-78aa-4779-bcd0-9918fe8a013c.png)

This fix makes `cad-libraries/config/tables` the default path for tables.
