### PR TITLE
Adding python scripts to generate actuator performance curves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 !*.pptx
 !*.xls
 !*.xlsx
+!*.py
 !*/
 # Accepted modelcheck files extension
 !*.mcc

--- a/scripts/actuator_curves/README.md
+++ b/scripts/actuator_curves/README.md
@@ -1,0 +1,29 @@
+## README
+
+This subfolder contains the following three python script files: 
+
+```
++-- actuator_curves
+|  components.py
+|  generateDB.py
+|  plotActuatorCurves.py
+```
+
+### `components.py`
+
+This script defines the classes of `motor`, `reducer` and the `actuator`. It also has the functions that `copmuteMotorCurves` as well as `computeActuatorCurves`. 
+
+### `generateDB.py`
+
+This scripts creates a dictionary database of components and actuators where each motor, reducer or actuator combination and all its parameters are defined. 
+
+### `plotActuatorCurves.py`
+
+This scripts extracts the data from the previously generated database and plots the actuator curves for teh actuator combination selected in the script. 
+
+
+### How to Use these Scripts: 
+
+1. Run the `generateDB.py`. This will create two databases, namely  `componentsDB.dat` and `actuatorsDB.dat`. 
+2. Comment/Uncomment the desired actuator combination from the ones defined in the script `plotActuatorCurves.py`.
+3. Run `plotActuatorCurves.py`. 

--- a/scripts/actuator_curves/components.py
+++ b/scripts/actuator_curves/components.py
@@ -1,0 +1,350 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Jun 23 07:28:03 2014
+
+@author: Alberto Parmiggiani
+
+Version History
+---------------
+XX.XX           YYYYMMDD   Author    Description
+01.00           201407??   alberto   first release
+02.00           20140825   alberto   fixed bug in efficiency curve calculation
+                                     (function reducer.__init__)
+03.00           20150417   alberto   modified actuator and motor curves code to
+                                     account for cases where some data are
+                                     missing
+04.00           20150901   alberto   modified the actuator init and curves
+                                     computation functions to fix an issue with
+                                     torque saturation for normal gearboxes
+
+"""
+
+import numpy as np
+from scipy import optimize
+
+
+class motor:
+    '''
+    Parameters
+    ----------
+    name : str
+        motor code / name
+    ratedTorque : float
+        motor rated torque in [Nm]
+        can be calculated from the rated speed and the rated power values
+    contStallTorque : float
+        motor continuous stall torque [Nm] 
+    peakTorque : float
+         motor peak torque [Nm]
+    ratedSpeed : float
+         motor rated speed [rpm] 
+    noLoadSpeed : float
+        motor no load speed [rpm]
+    torqueConst : float
+        motor torque constant [Nm/A]
+    backEMFConst : float
+       motor back-EMF constant [V/krpm]
+    designVoltage : float
+        motor operating voltage by design [V]
+        can be computed dividing the speed at rated power by the back EMF 
+        constant
+    busVoltage : float
+        motor actual operating voltage [V]
+    resistance : float
+        motor winding resistance [Ohms]
+    inductance : float
+        motor inductance [mH]
+    NPoles : int
+        number of magnetic poles
+    outerDiam : float
+        motor outer diameter [mm]
+    airgapDiam : float
+        motor airgap diameter [mm]
+    innerDiam : float
+        motor rotor inner diameter [mm]
+    tolalLength : float
+        totla motor length [mm]
+    stackLength : float
+        motor stack length [mm]
+    contCurveCoeffs : ndarray
+        coeiffcients of the polynomial curve defining the continuous operating 
+        region of the motor []
+
+    '''
+
+    def __init__(self, name,
+                 ratedTorque, contStallTorque, peakTorque,
+                 ratedSpeed, noLoadSpeed,
+                 torqueConst, backEMFConst,
+                 designVoltage, busVoltage, resistance, inductance, NPoles,
+                 outerDiam, airgapDiam, innerDiam, tolalLength, stackLength):
+        self.name = name
+        self.ratedTorque = ratedTorque
+        self.contStallTorque = contStallTorque
+        self.peakTorque = peakTorque
+        self.ratedSpeed = ratedSpeed
+        self.noLoadSpeed = noLoadSpeed
+        self.torqueConst = torqueConst
+        self.backEMFConst = backEMFConst
+        self.designVoltage = designVoltage
+        self.busVoltage = busVoltage
+        self.resistance = resistance
+        self.inductance = inductance
+        self.NPoles = NPoles
+        self.contCurveCoeffs = []
+
+        '''
+        if all needed data are provided compute the motor continuous operation 
+        curve.
+        The curve is computed as a third order polynomial passing through
+        the no load speed point, the stall torque point and the rated power
+        point with the form: omega = c1*tau**3 + c2*tau**2 + c3*tau + c4. 
+        The three coefficients are calculated with a constrained mimimization
+        procedure and stored in the contCurveCoeffs variable.
+        This is needed to enforce a proper shape of the polynomial, namely to 
+        assure c3 is negative or equal to zero.
+        '''
+
+        def f(x, nls, rs, rt, cst):
+            ''' return the sum of squared errors '''
+            s = [nls, rs, 0]
+            t = [0, rt, cst]
+            return np.sum((np.polyval(x, t) - s) ** 2)
+
+        if ratedTorque != [] and contStallTorque != [] and \
+                        ratedSpeed != [] and noLoadSpeed != []:
+            nls, rs, rt, cst = self.noLoadSpeed, self.ratedSpeed, \
+                               self.ratedTorque, self.contStallTorque
+            c = optimize.fmin_l_bfgs_b(f, np.array([0, 0, 0, nls]), \
+                                       args=(nls, rs, rt, cst), \
+                                       approx_grad=1, \
+                                       bounds=((None, 0), (None, 0), \
+                                               (None, 0), (None, nls)))
+            self.contCurveCoeffs = c[0]
+
+
+class reducer:
+    '''
+    Parameters
+    ----------
+    name : str
+        speed reducer code / name
+    reductionRatio : float
+        speed reducer reduction ratio [-]
+    efficiency : float
+        speed reducer efficiency [-]
+    efficiencyData : ndarray
+        values defining the values of angular velocity and corresponding 
+        efficiency values
+    maxContTorque : float
+        maximum repeatable peak torque [Nm]
+    maxTempTorque : float
+        momentary peak torque [Nm]
+    maxContSpeed : float
+        average input speed speed [rpm] 
+    maxTempSpeed : float
+        maximum input speed speed [rpm]
+    '''
+
+    def evalEff(self, x, a, b, c):
+        ''' exponential function to fit efficiency data '''
+        return a * np.exp(-b * x) + c
+
+    def __init__(self, name, reductionRatio, efficiency, efficiencyData,
+                 maxContTorque, maxTempTorque, maxContSpeed,
+                 maxTempSpeed):
+        self.name = name
+        self.reductionRatio = reductionRatio
+        self.efficiency = efficiency
+        self.efficiencyData = efficiencyData
+        ''' NOTE: values reported in the Harmonic
+            Drive data-sheet are already ground true and comprise the 
+            efficiency scaling '''
+        #        print(efficiencyData)
+        #        print(efficiency)
+        #        print (efficiencyData != [])
+        print(name)
+        print('max Torque', maxContTorque)
+        if efficiencyData != []:
+            self.maxContTorque = maxContTorque
+            self.maxTempTorque = maxTempTorque
+            print('scaling...', maxContTorque)
+        else:
+            self.maxContTorque = maxContTorque
+            self.maxTempTorque = maxTempTorque
+            print('not scaling...', maxContTorque)
+        self.maxContSpeed = maxContSpeed
+        self.maxTempSpeed = maxTempSpeed
+        self.efficiencyCoeffs = []
+        ''' add a fake point at 10000rpm to enforce an almost constant value of
+            the last part of the efficiency curve '''
+        if efficiencyData != []:
+            x = np.array(np.append(efficiencyData[0], 10000.0))
+            y = np.array(np.append(efficiencyData[1], efficiencyData[1][-1]))
+            ''' fit the efficiency data with an exponential function '''
+            self.efficiencyCoeffs, pcov = optimize.curve_fit(self.evalEff,
+                                                             x, y,
+                                                             [0, 0, 0.5])
+
+            # few lines for plotting for debug purposes
+            # t = np.linspace(0,8000,100)
+            # vv = self.evalEff(t, self.efficiencyCoeffs[0], self.efficiencyCoeffs[1], self.efficiencyCoeffs[2] )
+            # pl.figure()
+            # pl.plot(t,vv)
+            # pl.plot(x, y,'rx')
+
+
+class actuator:
+    def __init__(self, name, mot, red):
+        if name == []:
+            self.name = mot.name + ' ' + red.name
+        self.mot = mot
+        self.red = red
+
+    xy1 = []
+    xy2 = []
+    xy3 = []
+
+
+def computeMotorCurves(m):
+    '''
+    Compute the characteristic curves of a motor
+    
+    Return the x-y coordinates defining the continuous and temporary operating
+    regions of a given motor
+    
+    Parameters
+    ----------
+    m : motor
+        Electric motor (motor and speed reducer).
+    
+    Returns
+    -------
+    tau : ndarray
+        The vector defining the motor torque range.
+    y1 : ndarray
+        The vector defining the motor angular velocity in the continuous
+        operating region.
+    y2 : ndarray
+        The vector defining the temporary maximum motor angular velocity when 
+        the motor is run at its prescribed operating voltage.
+    y3 : ndarray
+        The vector defining the temporary maximum motor angular velocity when 
+        the motor is run with a bus voltage lower than the prescribed 
+        operating voltage.
+    '''
+    if m.contCurveCoeffs == []:
+        print('Warning: motor constant operating region coefficients not computed.')
+        pass
+    else:
+        tau = np.linspace(0, m.peakTorque, 150)
+        y1 = np.maximum(np.polyval(m.contCurveCoeffs, tau), 0)
+        ''' copy y1 to y2 and y3 so that if data are not available script does
+        not fail '''
+        y2, y3 = y1, y1
+        if m.designVoltage != [] and m.inductance != [] and m.resistance != [] and \
+                        m.backEMFConst != [] and m.NPoles != []:
+            ''' renaming constants to increase formula legibility '''
+            V, L, R, Bemf, Kt, p = m.designVoltage, m.inductance, \
+                                   m.resistance, m.backEMFConst / 1000, \
+                                   m.torqueConst, m.NPoles
+            ''' compute angular velocity limit curve taking into consideration
+                the limit caused by the inductance of the motor '''
+            y2 = (60 * np.sqrt((
+                               Kt ** 2 * L ** 2 * p ** 2 * tau ** 2 + 3600 * Bemf ** 2 * Kt ** 4) * V ** 2 - L ** 2 * p ** 2 * tau ** 4 * R ** 2) - 3600 * Bemf * Kt * tau * R) / (
+                 L ** 2 * p ** 2 * tau ** 2 + 3600 * Bemf ** 2 * Kt ** 2)
+            ''' using numpy.minumum to compare a vector to a scalar '''
+            np.minimum(y1, y2, y1)
+            ''' compute the limit curve if the bus voltage is different form 
+                the design voltage of the motor '''
+            if m.busVoltage != []:
+                V = m.busVoltage
+                y3 = (60 * np.sqrt((
+                                   Kt ** 2 * L ** 2 * p ** 2 * tau ** 2 + 3600 * Bemf ** 2 * Kt ** 4) * V ** 2 - L ** 2 * p ** 2 * tau ** 4 * R ** 2) - 3600 * Bemf * Kt * tau * R) / (
+                     L ** 2 * p ** 2 * tau ** 2 + 3600 * Bemf ** 2 * Kt ** 2)
+                np.minimum(y1, y3, y1)
+            else:
+                y3 = y2
+
+        y2 = np.append(y2, np.linspace(y2[-1], 0, 100))
+        y3 = np.append(y3, np.linspace(y3[-1], 0, 100))
+        return np.array([tau, y1]), \
+               np.array([np.append(tau, np.repeat(tau[-1], 100)), y2]), \
+               np.array([np.append(tau, np.repeat(tau[-1], 100)), y3])
+
+
+def computeActuatorCurves(a):
+    '''
+    Compute the characteristic curves of an actuator
+    
+    Return the x-y coordinates defining the continuous and temporary operating
+    regions of a given actuator
+    
+    Parameters
+    ----------
+    a : actuator
+        actuator type (motor and speed reducer).
+    
+    Returns
+    -------
+    tau : ndarray
+        The vector defining the actuator torque range (after the speed
+        reducer).
+    y1 : ndarray
+        The vector defining the actuator angular velocity (after the speed 
+        reducer) in the continuous operating region.
+    y2 : ndarray
+        The vector defining the temporary maximum actuator angular velocity 
+        (after the speed reducer) when the actuator is run at its prescribed
+        operating voltage.
+    y3 : ndarray
+        The vector defining the temporary maximum actuator angular velocity 
+        (after the speed reducer) when the actuator is run with a bus voltage 
+        lower than the prescribed operating voltage.
+        
+    '''
+
+    ''' compute motor torques '''
+    xy1, xy2, xy3 = computeMotorCurves(a.mot)
+
+    ''' scale torques by the reducer reduction ratio '''
+    xy1[0] = xy1[0] * a.red.reductionRatio
+    xy2[0] = xy2[0] * a.red.reductionRatio
+    xy3[0] = xy3[0] * a.red.reductionRatio
+
+    ''' apply speed reducer maximum speed saturation '''
+    if a.red.maxContSpeed != []:
+        np.minimum(xy1[1], a.red.maxContSpeed, xy1[1])
+        np.minimum(xy2[1], a.red.maxTempSpeed, xy2[1])
+        np.minimum(xy3[1], a.red.maxTempSpeed, xy3[1])
+
+    elif a.red.efficiency != []:
+        xy1[0] = xy1[0] * a.red.efficiency
+        xy2[0] = xy2[0] * a.red.efficiency
+        xy3[0] = xy3[0] * a.red.efficiency
+
+    ''' scale the angular velocities by the reducer reduction ratio '''
+    xy1[1] = xy1[1] / a.red.reductionRatio
+    xy2[1] = xy2[1] / a.red.reductionRatio
+    xy3[1] = xy3[1] / a.red.reductionRatio
+
+    ''' if the efficiency coefficients are available compute curves taking the
+        speed reducer efficiency into account '''
+    if a.red.efficiencyCoeffs != []:
+        xy1[0] = xy1[0] * a.red.evalEff(xy1[1], a.red.efficiencyCoeffs[0],
+                                        a.red.efficiencyCoeffs[1], a.red.efficiencyCoeffs[2])
+        xy2[0] = xy2[0] * a.red.evalEff(xy2[1], a.red.efficiencyCoeffs[0],
+                                        a.red.efficiencyCoeffs[1], a.red.efficiencyCoeffs[2])
+        xy3[0] = xy3[0] * a.red.evalEff(xy3[1], a.red.efficiencyCoeffs[0],
+                                        a.red.efficiencyCoeffs[1], a.red.efficiencyCoeffs[2])
+
+    ''' apply speed reducer maximum torque saturation
+        NOTE: the point of application of this saturation in the script is
+        critical. If the saturation is applied before the efficiency scaling
+        the script yileds wrong results. '''
+    if a.red.maxContTorque != []:
+        xy1[0][xy1[0] > a.red.maxContTorque] = a.red.maxContTorque
+        xy2[0][xy2[0] > a.red.maxTempTorque] = a.red.maxTempTorque
+        xy3[0][xy3[0] > a.red.maxTempTorque] = a.red.maxTempTorque
+
+    return xy1, xy2, xy3

--- a/scripts/actuator_curves/generateDB.py
+++ b/scripts/actuator_curves/generateDB.py
@@ -403,7 +403,7 @@ def main():
               contStallTorque=0.6, #(?)
               peakTorque=0.96,
               ratedSpeed=6850,
-              noLoadSpeed=6850, #(?)
+              noLoadSpeed=12000, #mech no load speed
               torqueConst=0.058,
               backEMFConst=7.007, #(?)
               designVoltage=48,
@@ -422,8 +422,8 @@ def main():
               ratedTorque=0.66,
               contStallTorque=1.3, #(?)
               peakTorque=2.13,
-              ratedSpeed=3650,
-              noLoadSpeed=6300, #(?)
+              ratedSpeed=6300,
+              noLoadSpeed=10000, #mech no load speed
               torqueConst=0.109,
               backEMFConst=7.619, #(?)
               designVoltage=48,

--- a/scripts/actuator_curves/generateDB.py
+++ b/scripts/actuator_curves/generateDB.py
@@ -1,0 +1,530 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Jul 16 13:34:38 2014
+
+@author: Alberto Parmiggiani
+
+Version History
+---------------
+XX.XX           YYYYMMDD   Author    Description
+01.00           2014????   alberto   first release
+02.00           20150831   alberto   added Mecapion motor
+
+"""
+
+from components import *
+import shelve
+
+
+def main():
+    ''' open a dictionary to save all components data '''
+    dictComp = shelve.open("componentsDB", writeback=True)
+    ''' open a dictionary to save all actuator data '''
+    dictAct = shelve.open("actuatorsDB", writeback=True)
+    # insert component and corresponding data
+    dictComp['Faulhaber 1016M012'] = \
+        motor('Faulhaber 1016M012', 0.0013, 0.00289, [], 6650, 14700, [], [], 12, [], 31.6, 344, [], [], [], [], [], [])
+    dictComp['Faulhaber 1224N012'] = \
+        motor('Faulhaber 1224N012', 0.0017, [], [], 8500, [], [], [], 12, [], [], [], [], [], [], [], [], [])
+    dictComp['Faulhaber 2342S012CR'] = \
+        motor(name='Faulhaber 2342S012CR',
+              ratedTorque=0.017,
+              contStallTorque=0.08,
+              peakTorque=0.23,
+              ratedSpeed=7000,
+              noLoadSpeed=12000,
+              torqueConst=0.0134,
+              backEMFConst=1.4,
+              designVoltage=12,
+              busVoltage=[],
+              resistance=1.9,
+              inductance=0.101 / 1000,
+              NPoles=[],
+              outerDiam=23,
+              airgapDiam=[],
+              innerDiam=[],
+              tolalLength=42,
+              stackLength=[])
+    dictComp['Kollmorgen RBE00513-A'] = \
+        motor(name='Kollmorgen RBE00513-A',
+              ratedTorque=0.057948,
+              contStallTorque=0.0854,
+              peakTorque=0.23,
+              ratedSpeed=11700,
+              noLoadSpeed=18000,
+              torqueConst=0.0226,
+              backEMFConst=2.36,
+              designVoltage=28,
+              busVoltage=[],
+              resistance=1.11,
+              inductance=0.34 / 1000,
+              NPoles=6,
+              outerDiam=26.67,
+              airgapDiam=12,
+              innerDiam=4.80,
+              tolalLength=34.54,
+              stackLength=25.4)
+    dictComp['Kollmorgen RBE01211-A'] = \
+        motor(name='Kollmorgen RBE01211-A',
+              ratedTorque=0.15,
+              contStallTorque=0.22,
+              peakTorque=0.806,
+              ratedSpeed=9680,
+              noLoadSpeed=14000,
+              torqueConst=0.041,
+              backEMFConst=4.29,
+              designVoltage=42,
+              busVoltage=[],
+              resistance=0.664,
+              inductance=0.32 / 1000,
+              NPoles=8,
+              outerDiam=[],
+              airgapDiam=[],
+              innerDiam=[],
+              tolalLength=[],
+              stackLength=[])
+    dictComp['Kollmorgen RBE01210-A'] = \
+        motor(name='Kollmorgen RBE01210-A',
+              ratedTorque=0.07335,
+              contStallTorque=0.22,
+              peakTorque=0.806,
+              ratedSpeed=9680,
+              noLoadSpeed=18500,
+              torqueConst=0.041,
+              backEMFConst=4.29,
+              designVoltage=42,
+              busVoltage=[],
+              resistance=0.664,
+              inductance=0.32 / 1000,
+              NPoles=8,
+              outerDiam=[],
+              airgapDiam=[],
+              innerDiam=[],
+              tolalLength=[],
+              stackLength=[])
+    dictComp['Kollmorgen RBE01510-A'] = \
+        motor(name='Kollmorgen RBE01510-A',
+              ratedTorque=0.1218,
+              contStallTorque=0.19,
+              peakTorque=0.55,
+              ratedSpeed=7450,
+              noLoadSpeed=11500,
+              torqueConst=0.0407,
+              backEMFConst=4.26,
+              designVoltage=32,
+              busVoltage=[],
+              resistance=0.814,
+              inductance=0.32 / 1000,
+              NPoles=12,
+              outerDiam=[],
+              airgapDiam=[],
+              innerDiam=[],
+              tolalLength=[],
+              stackLength=[])
+    dictComp['Kollmorgen RBE01511-A'] = \
+        motor(name='Kollmorgen RBE01511-A',
+              ratedTorque=0.2316,
+              contStallTorque=0.384,
+              peakTorque=1.15,
+              ratedSpeed=5400,
+              noLoadSpeed=8333,
+              torqueConst=0.0833,
+              backEMFConst=8.73,
+              designVoltage=47,
+              busVoltage=[],
+              resistance=1.04,
+              inductance=0.58 / 1000,
+              NPoles=12,
+              outerDiam=[],
+              airgapDiam=[],
+              innerDiam=[],
+              tolalLength=[],
+              stackLength=[])
+    dictComp['Kollmorgen RBE01810-A'] = \
+        motor(name='Kollmorgen RBE01810-A',
+              ratedTorque=0.2835,
+              contStallTorque=0.429,
+              peakTorque=1.53,
+              ratedSpeed=7040,
+              noLoadSpeed=10250,
+              torqueConst=0.0855,
+              backEMFConst=8.95,
+              designVoltage=63,
+              busVoltage=[],
+              resistance=1.22,
+              inductance=0.9 / 1000,
+              NPoles=12,
+              outerDiam=[],
+              airgapDiam=[],
+              innerDiam=[],
+              tolalLength=[],
+              stackLength=[])
+    dictComp['Kollmorgen RBE01811-C'] = \
+        motor(name='Kollmorgen RBE01811-C',
+              ratedTorque=0.546,
+              contStallTorque=0.856,
+              peakTorque=3.04,
+              ratedSpeed=5250,
+              noLoadSpeed=7500,
+              torqueConst=0.121,
+              backEMFConst=12.7,
+              designVoltage=67,
+              busVoltage=[],
+              resistance=0.753,
+              inductance=0.92 / 1000,
+              NPoles=12,
+              outerDiam=[],
+              airgapDiam=[],
+              innerDiam=[],
+              tolalLength=[],
+              stackLength=[])
+    dictComp['MOOG C2900525'] = \
+        motor(name='MOOG C2900525',
+              ratedTorque=0.18,
+              contStallTorque=0.22,
+              peakTorque=0.8,
+              ratedSpeed=6000,
+              noLoadSpeed=11900,
+              torqueConst=0.047,
+              backEMFConst=4.08,
+              designVoltage=48,
+              busVoltage=[],
+              resistance=0.682,
+              inductance=0.452 / 1000,
+              NPoles=8,
+              outerDiam=[],
+              airgapDiam=[],
+              innerDiam=[],
+              tolalLength=[],
+              stackLength=[])
+    dictComp['MOOG C2900524'] = \
+        motor(name='MOOG C2900524',
+              ratedTorque=0.09,
+              contStallTorque=0.11,
+              peakTorque=0.8,
+              ratedSpeed=6000,
+              noLoadSpeed=22160,
+              torqueConst=0.025,
+              backEMFConst=2.2,
+              designVoltage=48,
+              busVoltage=[],
+              resistance=0.731,
+              inductance=0.34 / 1000,
+              NPoles=8,
+              outerDiam=[],
+              airgapDiam=[],
+              innerDiam=[],
+              tolalLength=[],
+              stackLength=[])
+    dictComp['Maxon EC-i 40 70W 36V'] = \
+        motor(name='Maxon EC-i 40 70W 36V',
+              ratedTorque=0.075,
+              contStallTorque=0.0829,
+              peakTorque=1.41,
+              ratedSpeed=6000,
+              noLoadSpeed=10700,
+              torqueConst=0.0315,
+              backEMFConst=2.2,
+              designVoltage=36,
+              busVoltage=[],
+              resistance=0.807,
+              inductance=0.644 / 1000,
+              NPoles=7,
+              outerDiam=40,
+              airgapDiam=[],
+              innerDiam=[],
+              tolalLength=36,
+              stackLength=[])
+    dictComp['Mavilor FC13'] = \
+        motor(name='Mavilor FC13',
+              ratedTorque=0.15,
+              contStallTorque=0.2,
+              peakTorque=1.2,
+              ratedSpeed=10000,
+              noLoadSpeed=20000,
+              torqueConst=0.018,
+              backEMFConst=1.885,
+              designVoltage=36,
+              busVoltage=[],
+              resistance=0.169,
+              inductance=0.025 / 1000,
+              NPoles=4,
+              outerDiam=32,
+              airgapDiam=[],
+              innerDiam=[],
+              tolalLength=70,
+              stackLength=[])
+    # TODO: check ratedTorque and ratedSpeed
+    dictComp['Mecapion APM-SA01A'] = \
+        motor(name='Mecapion APM-SA01A',
+              ratedTorque=0.318,
+              contStallTorque=0.35,
+              peakTorque=0.95,
+              ratedSpeed=3000,
+              noLoadSpeed=5000,
+              torqueConst=0.135,
+              backEMFConst=12.7,
+              designVoltage=48,
+              busVoltage=[],
+              resistance=2.9,
+              inductance=0.2 / 1000,
+              NPoles=4,
+              outerDiam=40,
+              airgapDiam=[],
+              innerDiam=[],
+              tolalLength=70,
+              stackLength=[])
+
+    dictComp['HPC M1 40-1 worm drive'] = \
+        reducer(name='HPC M1 40-1 worm drive',
+                reductionRatio=40,
+                efficiency=0.25,
+                efficiencyData=[],
+                maxContTorque=40,
+                maxTempTorque=40,
+                maxContSpeed=[],
+                maxTempSpeed=[])
+
+    dictComp['HPC M1 120-1 worm drive'] = \
+        reducer(name='HPC M1 120-1 worm drive',
+                reductionRatio=120,
+                efficiency=0.25,
+                efficiencyData=[],
+                maxContTorque=40,
+                maxTempTorque=40,
+                maxContSpeed=[],
+                maxTempSpeed=[])
+
+    dictComp['Harmonic Drive HFUC-2A 8-100'] = \
+        reducer(name='Harmonic Drive HFUC-2A 8-100',
+                reductionRatio=100,
+                efficiency=[],
+                efficiencyData=[[500, 1000, 2000, 3500],
+                                [0.83, 0.8, 0.75, 0.7]],
+                maxContTorque=3.3,
+                maxTempTorque=4.8,
+                maxContSpeed=6500,
+                maxTempSpeed=14000)
+    dictComp['Harmonic Drive HFUC-2A 14-100'] = \
+        reducer(name='Harmonic Drive HFUC-2A 14-100',
+                reductionRatio=100,
+                efficiency=[],
+                efficiencyData=[[500, 1000, 2000, 3500],
+                                [0.83, 0.8, 0.75, 0.7]],
+                maxContTorque=11,
+                maxTempTorque=28,
+                maxContSpeed=3500,
+                maxTempSpeed=8500)
+    dictComp['Harmonic Drive HFUC-2A 17-100'] = \
+        reducer(name='Harmonic Drive HFUC-2A 17-100',
+                reductionRatio=100,
+                efficiency=[],
+                efficiencyData=[[500, 1000, 2000, 3500],
+                                [0.85, 0.82, 0.78, 0.74]],
+                maxContTorque=39,
+                maxTempTorque=54,
+                maxContSpeed=3500,
+                maxTempSpeed=7300)
+    dictComp['Harmonic Drive HFUC-2A 20-100'] = \
+        reducer(name='Harmonic Drive HFUC-2A 20-100',
+                reductionRatio=100,
+                efficiency=[],
+                efficiencyData=[[500, 1000, 2000, 3500],
+                                [0.85, 0.82, 0.78, 0.74]],
+                maxContTorque=49,
+                maxTempTorque=82,
+                maxContSpeed=3500,
+                maxTempSpeed=6500)
+    dictComp['Harmonic Drive HFUC-2A 25-100'] = \
+        reducer(name='Harmonic Drive HFUC-2A 25-100',
+                reductionRatio=100,
+                efficiency=[],
+                efficiencyData=[[500, 1000, 2000, 3500],
+                                [0.85, 0.82, 0.78, 0.74]],
+                maxContTorque=108,
+                maxTempTorque=157,
+                maxContSpeed=3500,
+                maxTempSpeed=6500)
+    dictComp['Harmonic Drive CSD-2A 17-100'] = \
+        reducer(name='Harmonic Drive CSD-2A 17-100',
+                reductionRatio=100,
+                efficiency=[],
+                efficiencyData=[[500, 1000, 2000, 3500],
+                                [0.79, 0.75, 0.70, 0.64]],
+                maxContTorque=27,
+                maxTempTorque=37,
+                maxContSpeed=3500,
+                maxTempSpeed=7300)
+    dictComp['Harmonic Drive CSD-2A 14-100'] = \
+        reducer(name='Harmonic Drive CSD-2A 14-100',
+                reductionRatio=100,
+                efficiency=[],
+                efficiencyData=[[500, 1000, 2000, 3500],
+                                [0.72, 0.68, 0.62, 0.55]],
+                maxContTorque=7.7,
+                maxTempTorque=19,
+                maxContSpeed=3500,
+                maxTempSpeed=7300)
+    dictComp['Harmonic Drive CSD-2UH 20-100'] = \
+        reducer(name='Harmonic Drive CSD-2UH 20-100',
+                reductionRatio=100,
+                efficiency=[],
+                efficiencyData=[[500, 1000, 2000, 3500],
+                                [0.79, 0.75, 0.70, 0.64]],
+                maxContTorque=34,
+                maxTempTorque=57,
+                maxContSpeed=3500,
+                maxTempSpeed=6500)
+
+    dictComp['none'] = \
+        reducer(name='none',
+                reductionRatio=1,
+                efficiency=[],
+                efficiencyData=[],
+                maxContTorque=[],
+                maxTempTorque=[],
+                maxContSpeed=[],
+                maxTempSpeed=[])
+
+    dictComp['MOOG C2900525'].busVoltage = 36
+    dictComp['Kollmorgen RBE01210-A'].busVoltage = 40
+    dictComp['Kollmorgen RBE01211-A'].busVoltage = 40
+    dictComp['Kollmorgen RBE01510-A'].busVoltage = dictComp['Kollmorgen RBE01510-A'].designVoltage
+    dictComp['Kollmorgen RBE01510-A'].designVoltage = 36
+    dictComp['Kollmorgen RBE01511-A'].busVoltage = 36
+    dictComp['Kollmorgen RBE01810-A'].busVoltage = 36
+    dictComp['Mecapion APM-SA01A'].busVoltage = 24
+
+    aStr = 'iCub3 medium actuator'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['MOOG C2900525'],
+                             red=dictComp['Harmonic Drive HFUC-2A 17-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'iCub3 low power actuator'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['MOOG C2900524'],
+                             red=dictComp['Harmonic Drive HFUC-2A 17-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'RBE00513A + CSD 14 100'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['Kollmorgen RBE00513-A'],
+                             red=dictComp['Harmonic Drive CSD-2A 14-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'RBE01210A + CSD 14 100'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['Kollmorgen RBE01210-A'],
+                             red=dictComp['Harmonic Drive CSD-2A 14-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'RBE01211A + CSD 17 100'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['Kollmorgen RBE01211-A'],
+                             red=dictComp['Harmonic Drive CSD-2A 17-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'C2900524 + CSD 17 100'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['MOOG C2900524'],
+                             red=dictComp['Harmonic Drive CSD-2A 17-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'C2900525 + CSD 17 100'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['MOOG C2900525'],
+                             red=dictComp['Harmonic Drive CSD-2A 17-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'C2900525 + CSD-2UH 20 100'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['MOOG C2900525'],
+                             red=dictComp['Harmonic Drive CSD-2UH 20-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'iCub3 high power actuator var1'  # not good
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['Kollmorgen RBE01510-A'],
+                             red=dictComp['Harmonic Drive HFUC-2A 20-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'iCub3 high power actuator var2'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['Kollmorgen RBE01511-A'],
+                             red=dictComp['Harmonic Drive HFUC-2A 20-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'iCub3 high power actuator var3'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['Kollmorgen RBE01511-A'],
+                             red=dictComp['Harmonic Drive HFUC-2A 25-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'iCub3 high power actuator var4'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['Kollmorgen RBE01810-A'],
+                             red=dictComp['Harmonic Drive HFUC-2A 25-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'CER joint 1 w. Maxon'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['Maxon EC-i 40 70W 36V'],
+                             red=dictComp['HPC M1 40-1 worm drive'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'CER joint 1 w. Mecapion i=40:1'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['Mecapion APM-SA01A'],
+                             red=dictComp['HPC M1 40-1 worm drive'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'CER joint 1 w. Mecapion i=120:1'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['Mecapion APM-SA01A'],
+                             red=dictComp['HPC M1 120-1 worm drive'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'Maxon EC-i 40 70W 36V'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['Maxon EC-i 40 70W 36V'],
+                             red=dictComp['none'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'Mavilor FC13'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['Mavilor FC13'],
+                             red=dictComp['none'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'iCub2 prono-supination'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['Faulhaber 2342S012CR'],
+                             red=dictComp['Harmonic Drive HFUC-2A 8-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    dictComp.sync()
+    dictAct.sync()
+    dictComp.close()
+    dictAct.close()
+
+
+main()

--- a/scripts/actuator_curves/generateDB.py
+++ b/scripts/actuator_curves/generateDB.py
@@ -9,6 +9,7 @@ Version History
 XX.XX           YYYYMMDD   Author    Description
 01.00           2014????   alberto   first release
 02.00           20150831   alberto   added Mecapion motor
+03.00           20220603     divya   added eCub joint components & actuators
 
 """
 
@@ -395,6 +396,69 @@ def main():
     dictComp['Kollmorgen RBE01810-A'].busVoltage = 36
     dictComp['Mecapion APM-SA01A'].busVoltage = 24
 
+    # TODO: verify all data from TQ ILM 50x08 & CPL 20-160    
+    dictComp['TQ ILM 50x08 SS'] = \
+        motor(name='TQ ILM 50x08 SS',
+              ratedTorque=0.30,
+              contStallTorque=0.6, #(?)
+              peakTorque=0.96,
+              ratedSpeed=6850,
+              noLoadSpeed=6850, #(?)
+              torqueConst=0.058,
+              backEMFConst=7.007, #(?)
+              designVoltage=48,
+              busVoltage=[], # 32 (?)
+              resistance=0.54,
+              inductance=0.49/1000,
+              NPoles=10,
+              outerDiam=50,
+              airgapDiam=[],
+              innerDiam=30,
+              tolalLength=16.4,
+              stackLength=[]) 
+
+    dictComp['TQ ILM 70x10 DS'] = \
+        motor(name='TQ ILM 70x10 DS',
+              ratedTorque=0.66,
+              contStallTorque=1.3, #(?)
+              peakTorque=2.13,
+              ratedSpeed=3650,
+              noLoadSpeed=6300, #(?)
+              torqueConst=0.109,
+              backEMFConst=7.619, #(?)
+              designVoltage=48,
+              busVoltage=[], # 32 (?)
+              resistance=0.47,
+              inductance=0.91/1000,
+              NPoles=10,
+              outerDiam=69,
+              airgapDiam=[],
+              innerDiam=42,
+              tolalLength=22.6,
+              stackLength=[]) 
+        
+    dictComp['Harmonic Drive CPL-2A 20-160'] = \
+        reducer(name='Harmonic Drive CPL-2A 20-160',
+                reductionRatio=160,
+                efficiency=[], #0.74
+                efficiencyData=[[500, 1000, 2000, 3500],
+                                [0.78, 0.74, 0.66, 0.58]],
+                maxContTorque=49, #average torque
+                maxTempTorque=92, #repeatable peak
+                maxContSpeed=3500,
+                maxTempSpeed=6500)        
+
+    dictComp['Harmonic Drive CSD-2A 25-160'] = \
+        reducer(name='Harmonic Drive CSD-2A 25-160',
+                reductionRatio=160,
+                efficiency=[], #0.66
+                efficiencyData=[[500, 1000, 2000, 3500],
+                                [0.72, 0.66, 0.57, 0.50]],
+                maxContTorque=75, #average torque
+                maxTempTorque=123, #repeatable peak
+                maxContSpeed=3500,
+                maxTempSpeed=5600)
+
     aStr = 'iCub3 medium actuator'
     dictAct[aStr] = actuator(name=aStr,
                              mot=dictComp['MOOG C2900525'],
@@ -518,6 +582,27 @@ def main():
     dictAct[aStr] = actuator(name=aStr,
                              mot=dictComp['Faulhaber 2342S012CR'],
                              red=dictComp['Harmonic Drive HFUC-2A 8-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'eCub2 small joint'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['TQ ILM 50x08 SS'],
+                             red=dictComp['Harmonic Drive CSD-2A 17-100'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'eCub2 medium joint'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['TQ ILM 50x08 SS'],
+                             red=dictComp['Harmonic Drive CPL-2A 20-160'])
+    dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
+        computeActuatorCurves(dictAct[aStr])
+
+    aStr = 'eCub2 large joint'
+    dictAct[aStr] = actuator(name=aStr,
+                             mot=dictComp['TQ ILM 70x10 DS'],
+                             red=dictComp['Harmonic Drive CSD-2A 25-160'])
     dictAct[aStr].xy1, dictAct[aStr].xy2, dictAct[aStr].xy3 = \
         computeActuatorCurves(dictAct[aStr])
 

--- a/scripts/actuator_curves/plotActuatorCurves.py
+++ b/scripts/actuator_curves/plotActuatorCurves.py
@@ -3,6 +3,13 @@
 Created on Mon Jun 23 07:28:03 2014
 
 @author: Alberto Parmiggiani
+
+Version History
+---------------
+XX.XX           YYYYMMDD   Author    Description
+01.00           20140623   alberto   first release (?)
+02.00           20220603     divya   added eCub actuator combinations
+
 """
 
 import shelve
@@ -53,6 +60,24 @@ def main():
 #    pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'c', label = aStr)
 #    pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'c--')
 #    pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'c-.')
+
+#   #eCub 2.0 small joint
+#    aStr = 'eCub2 small joint'
+#    pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'y', label = aStr)
+#    pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'y--')
+#    pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'y-.')
+
+#   #eCub 2.0 medium joint
+#    aStr = 'eCub2 medium joint'
+#    pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'y', label = aStr)
+#    pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'y--')
+#    pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'y-.')
+    
+#   #eCub 2.0 large joint
+#    aStr = 'eCub2 large joint'
+#    pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'y', label = aStr)
+#    pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'y--')
+#    pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'y-.') 
  
     pl.ylabel(r'$\tau$ [Nm]')
     pl.xlabel(r'$\omega$ [rpm]')

--- a/scripts/actuator_curves/plotActuatorCurves.py
+++ b/scripts/actuator_curves/plotActuatorCurves.py
@@ -8,7 +8,7 @@ Version History
 ---------------
 XX.XX           YYYYMMDD   Author    Description
 01.00           20140623   alberto   first release (?)
-02.00           20220603     divya   added eCub actuator combinations
+02.00           20220603     divya   added eCub actuator combinations + bug fix
 
 """
 
@@ -20,65 +20,65 @@ def main():
     # open the dictionary containing all components data
     dictAct = shelve.open("actuatorsDB", writeback=True)
     
-#    aStr = 'iCub2 prono-supination'
-#     pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'b', label = aStr)
-#     pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'b--')
-#     pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'b-.')
+    # aStr = 'iCub2 prono-supination'
+    # pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'b', label = 'nominal')
+    # pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'b--', label = 'peak')
+    # pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'b-.')
     
-#    aStr = 'RBE01210A + CSD 14 100'
-#    pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'c', label = aStr)
-#    pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'c--')
-#    pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'c-.')
+    # aStr = 'RBE01210A + CSD 14 100'
+    # pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'c', label = 'nominal')
+    # pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'c--', label = 'peak')
+    # pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'c-.')
 
-#    aStr = 'RBE00513A + CSD 14 100'
-#    pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'm', label = aStr)
-#    pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'm--')
-#    pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'm-.')
+    # aStr = 'RBE00513A + CSD 14 100'
+    # pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'm', label = 'nominal')
+    # pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'm--', label = 'peak')
+    # pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'm-.')
 
-#    
-#    aStr = 'C2900524 + CSD 17 100'
-#    pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'm', label = aStr)
-#    pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'm--')
-#    pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'm-.')
-#    
-    aStr = 'C2900525 + CSD 17 100'
-    pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'r', label = aStr)
-    pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'r--')
-    pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'r-.')
-#
-#    aStr = 'C2900525 + CSD-2UH 20 100'
-#    pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'g', label = aStr)
-#    pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'g--')
-#    pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'g-.')
-
-#    aStr = 'CER joint 1 w. Mecapion i=40:1'
-#    pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'b', label = aStr)
-#    pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'b--')
-#    pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'b-.')
-#    
-#    aStr = 'CER joint 1 w. Mecapion i=120:1'
-#    pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'c', label = aStr)
-#    pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'c--')
-#    pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'c-.')
-
-#   #eCub 2.0 small joint
-#    aStr = 'eCub2 small joint'
-#    pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'y', label = aStr)
-#    pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'y--')
-#    pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'y-.')
-
-#   #eCub 2.0 medium joint
-#    aStr = 'eCub2 medium joint'
-#    pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'y', label = aStr)
-#    pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'y--')
-#    pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'y-.')
     
-#   #eCub 2.0 large joint
-#    aStr = 'eCub2 large joint'
-#    pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'y', label = aStr)
-#    pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'y--')
-#    pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'y-.') 
- 
+    # aStr = 'C2900524 + CSD 17 100'
+    # pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'm', label = 'nominal')
+    # pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'm--', label = 'peak')
+    # pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'm-.')
+    
+    # aStr = 'C2900525 + CSD 17 100'
+    # pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'r', label = 'nominal')
+    # pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'r--', label = 'peak')
+    # pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'r-.')
+
+    # aStr = 'C2900525 + CSD-2UH 20 100'
+    # pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'g', label = 'nominal')
+    # pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'g--', label = 'peak')
+    # pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'g-.')
+
+    # aStr = 'CER joint 1 w. Mecapion i=40:1'
+    # pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'b', label = 'nominal')
+    # pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'b--', label = 'peak')
+    # pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'b-.')
+    
+    # aStr = 'CER joint 1 w. Mecapion i=120:1'
+    # pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'c', label = 'nominal')
+    # pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'c--', label = 'peak')
+    # pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'c-.')
+
+    # eCub 2.0 actuator combinations
+
+    # aStr = 'eCub2 small joint'
+    # pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'y', label = 'nominal')
+    # pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'y--', label = 'peak')
+    # pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'y-.')
+
+    aStr = 'eCub2 medium joint'
+    pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'g', label = 'nominal')
+    pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'g--', label = 'peak')
+    pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'g-.')
+    
+    # aStr = 'eCub2 large joint'
+    # pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'b', label = 'nominal')
+    # pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'b--', label = 'peak')
+    # pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'b-.') 
+    
+    pl.title(aStr)
     pl.ylabel(r'$\tau$ [Nm]')
     pl.xlabel(r'$\omega$ [rpm]')
     pl.legend()

--- a/scripts/actuator_curves/plotActuatorCurves.py
+++ b/scripts/actuator_curves/plotActuatorCurves.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Jun 23 07:28:03 2014
+
+@author: Alberto Parmiggiani
+"""
+
+import shelve
+import matplotlib.pyplot as pl
+
+             
+def main():
+    # open the dictionary containing all components data
+    dictAct = shelve.open("actuatorsDB", writeback=True)
+    
+#    aStr = 'iCub2 prono-supination'
+#     pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'b', label = aStr)
+#     pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'b--')
+#     pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'b-.')
+    
+#    aStr = 'RBE01210A + CSD 14 100'
+#    pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'c', label = aStr)
+#    pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'c--')
+#    pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'c-.')
+
+#    aStr = 'RBE00513A + CSD 14 100'
+#    pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'm', label = aStr)
+#    pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'm--')
+#    pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'm-.')
+
+#    
+#    aStr = 'C2900524 + CSD 17 100'
+#    pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'm', label = aStr)
+#    pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'm--')
+#    pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'm-.')
+#    
+    aStr = 'C2900525 + CSD 17 100'
+    pl.plot(dictAct[aStr].xy1[1], dictAct[aStr].xy1[0], 'r', label = aStr)
+    pl.plot(dictAct[aStr].xy2[1], dictAct[aStr].xy2[0], 'r--')
+    pl.plot(dictAct[aStr].xy3[1], dictAct[aStr].xy3[0], 'r-.')
+#
+#    aStr = 'C2900525 + CSD-2UH 20 100'
+#    pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'g', label = aStr)
+#    pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'g--')
+#    pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'g-.')
+
+#    aStr = 'CER joint 1 w. Mecapion i=40:1'
+#    pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'b', label = aStr)
+#    pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'b--')
+#    pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'b-.')
+#    
+#    aStr = 'CER joint 1 w. Mecapion i=120:1'
+#    pl.plot(dictAct[aStr].xy1[0], dictAct[aStr].xy1[1], 'c', label = aStr)
+#    pl.plot(dictAct[aStr].xy2[0], dictAct[aStr].xy2[1], 'c--')
+#    pl.plot(dictAct[aStr].xy3[0], dictAct[aStr].xy3[1], 'c-.')
+ 
+    pl.ylabel(r'$\tau$ [Nm]')
+    pl.xlabel(r'$\omega$ [rpm]')
+    pl.legend()
+    pl.show()
+
+    dictAct.close()
+
+main()


### PR DESCRIPTION
We had old python scripts that were used to generate the Torque vs Speed performance curves for various joints used in our robots. I used them during the study for the design of new ergoCub 2.0 joints (https://github.com/icub-tech-iit/ergocub-design-joint/issues/65#issuecomment-1148797843).

With this PR, I am adding the old scripts to this repo, modifying them to add the proposed ecub joint combinations (https://github.com/icub-tech-iit/ergocub-design-joint/issues/64#issuecomment-1088890598)  and to fix some minor bugs. 
I added a README on how to use the script. 
They can now be used to generate actuator performance curves for any desired desired joint combination from the database.  

Also, I modified the `.gitignore` in order to allow committing python files. 

cc @icub-tech-iit/silo-mech 
