### PR TITLE
Add simulation_model\ergocub_1-x to the search path

### DIFF
--- a/config/search_path.pro
+++ b/config/search_path.pro
@@ -87,7 +87,7 @@ search_path ".\..\cad-mechanics\projects\simulation_model"
 search_path ".\..\cad-mechanics\projects\simulation_model\head"
 search_path ".\..\cad-mechanics\projects\simulation_model\icub3"
 search_path ".\..\cad-mechanics\projects\simulation_model\ergocub_1-0"
-search_path ".\..\cad-mechanics\projects\simulation_model\ergocub_1-1"
+search_path ".\..\cad-mechanics\projects\simulation_model\ergocub_1-x"
 search_path ".\..\cad-mechanics\projects\simulation_model\cer"
 !
 search_path ".\..\cad-mechanics\projects\tools"


### PR DESCRIPTION
This fixes a regression in URDF pipeline after:
- https://github.com/icub-tech-iit/cad-mechanics/commit/53da530380416405a645c8b719854800b394b171

The path where the simulation model of egocub 1.1/1.3 changed from `cad-mechanics\projects\simulation_model\ergocub_1-1 ` to `cad-mechanics\projects\simulation_model\ergocub_1-x` 