### PR TITLE
adding material file

### DIFF
--- a/config/materials/shenzhen_mh_silicone_shore-50.mtl
+++ b/config/materials/shenzhen_mh_silicone_shore-50.mtl
@@ -1,0 +1,68 @@
+﻿ND_RelParSet_K01 = {
+
+Name = SHENZHEN_MH_SILICONE_SHORE-50
+
+PARAMETERS =
+{
+  Name = PTC_MATERIAL_TYPE
+  Type = Integer
+  Default = 9
+  Access = Locked
+},
+{
+  Name = PTC_FAILURE_CRITERION_TYPE
+  Type = String
+  Default = 'NONE'
+  Access = Locked
+},
+{
+  Name = PTC_FATIGUE_TYPE
+  Type = String
+  Default = 'NONE'
+  Access = Locked
+},
+{
+  Name = PTC_MATERIAL_SUB_TYPE
+  Type = String
+  Default = 'LINEAR'
+  Access = Locked
+},
+{
+  Name = PTC_MATERIAL_DESCRIPTION
+  Type = String
+  Default = 'Greenhouse silicone vulcanized mold adhesive
+shore 50'
+  Access = Full
+},
+{
+  Name = TEMPERATURE
+  Type = Real
+  Default = 0.000000e+00 C
+  Access = Full
+},
+{
+  Name = PTC_INITIAL_BEND_Y_FACTOR
+  Type = Real
+  Default = 5.000000e-01
+  Access = Full
+},
+{
+  Name = PTC_BEND_TABLE
+  Type = String
+  Default = ''
+  Access = Full
+},
+{
+  Name = PTC_MASS_DENSITY
+  Type = Real
+  Default = 1.150000e-06 kg / mm^3
+  Access = Full
+},
+{
+  Name = PTC_TENSILE_ULTIMATE_STRESS
+  Type = Real
+  Default = 8.000000e+03 kPa
+  Access = Full
+}
+
+}


### PR DESCRIPTION
Adding a new material file for the silicon covers' components.
The reasonable density I found on the web at shore 50 A is 1,13 g/cm^3.
The tensile strength on the datasheet is  7 MPa, but at shore 50 A is more reasonable to consider 8 MPa.

[MH Silicon(EN traslation).pdf](https://github.com/user-attachments/files/20349847/MH.Silicon.EN.traslation.pdf)
[PSTR500160080_TDS_CAS.pdf](https://github.com/user-attachments/files/20349880/PSTR500160080_TDS_CAS.pdf)
